### PR TITLE
[CORE-2452] Add navigate must have replace prop rule

### DIFF
--- a/lib/rules/navigate-must-have-replace-prop.js
+++ b/lib/rules/navigate-must-have-replace-prop.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Rule to enforce that Navigate components always have a replace prop
+ *
+ * Without explicit replace prop, the default behavior can cause broken back button
+ * navigation, especially in redirect scenarios where users get stuck in loops.
+ *
+ * Redirection loops occur when Navigate creates history entries that users can
+ * navigate back to, triggering the same redirect logic repeatedly (auth guards,
+ * route fallbacks, error redirects).
+ *
+ * This rule enforces explicit declaration to clarify navigation intent.
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'enforce that Navigate components always have a replace prop to prevent redirection loops',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      missingReplaceProp:
+        'Navigate component must have an explicit replace prop to prevent redirection loops',
+      replaceFalseNotAllowed:
+        'Navigate component should avoid replace={false} as it can cause redirection loops when users navigate back',
+    },
+  },
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        const elementName = node.openingElement.name;
+
+        // Check if this is a Navigate component
+        if (
+          elementName.type === 'JSXIdentifier' &&
+          elementName.name === 'Navigate'
+        ) {
+          const replaceProp = node.openingElement.attributes.find((attr) => {
+            return (
+              attr.type === 'JSXAttribute' &&
+              attr.name &&
+              attr.name.name === 'replace'
+            );
+          });
+
+          if (!replaceProp) {
+            context.report({
+              node: node.openingElement,
+              messageId: 'missingReplaceProp',
+            });
+          } else if (
+            replaceProp.value &&
+            replaceProp.value.type === 'JSXExpressionContainer' &&
+            replaceProp.value.expression.type === 'Literal' &&
+            replaceProp.value.expression.value === false
+          ) {
+            context.report({
+              node: replaceProp,
+              messageId: 'replaceFalseNotAllowed',
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidio/eslint-plugin-rules",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Additional eslint rules used in Tidio",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/navigate-must-have-replace-prop.js
+++ b/tests/lib/rules/navigate-must-have-replace-prop.js
@@ -1,0 +1,106 @@
+'use strict';
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/navigate-must-have-replace-prop'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+var ruleTester = new RuleTester();
+ruleTester.run('navigate-must-have-replace-prop', rule, {
+  valid: [
+    {
+      code: '<Navigate to="/home" replace={true} />',
+    },
+    {
+      code: '<Navigate to="/home" replace />',
+    },
+    {
+      code: '<Navigate to="/home" state={{ from: location }} replace={true} />',
+    },
+    {
+      code: '<div>Not a Navigate component</div>',
+    },
+    {
+      code: '<Link to="/home">Go home</Link>',
+    },
+    {
+      code: '<OtherComponent navigate={true} />',
+    },
+  ],
+
+  invalid: [
+    {
+      code: '<Navigate to="/home" />',
+      errors: [
+        {
+          messageId: 'missingReplaceProp',
+        },
+      ],
+    },
+    {
+      code: '<Navigate to="/home" replace={false} />',
+      errors: [
+        {
+          messageId: 'replaceFalseNotAllowed',
+        },
+      ],
+    },
+    {
+      code: '<Navigate to="/home" state={{ from: location }} />',
+      errors: [
+        {
+          messageId: 'missingReplaceProp',
+        },
+      ],
+    },
+    {
+      code: '<Navigate to="/home" state={{ from: location }} replace={false} />',
+      errors: [
+        {
+          messageId: 'replaceFalseNotAllowed',
+        },
+      ],
+    },
+    {
+      code: `
+        function MyComponent() {
+          return <Navigate to="/redirect" />;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingReplaceProp',
+        },
+      ],
+    },
+    {
+      code: `
+        const redirectComponent = (
+          <Navigate 
+            to="/dashboard" 
+            state={{ from: 'login' }}
+          />
+        );
+      `,
+      errors: [
+        {
+          messageId: 'missingReplaceProp',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
**Browser Back Button Issue**
When Navigate doesn't use replace, it adds entries to browser history. This creates a loop:
- User lands on page with `<Navigate to="/dashboard" />`
- Navigate redirects to /dashboard and adds history entry
- User hits back button → goes back to the redirect page
- Navigate fires again → redirects to /dashboard again
- User is stuck in loop, can't go back