### PR TITLE
Feature/no use navigate import jsg 2426

### DIFF
--- a/lib/rules/no-use-navigate-import-from-react-router-dom.js
+++ b/lib/rules/no-use-navigate-import-from-react-router-dom.js
@@ -5,7 +5,7 @@
  * that can occur with the standard useNavigate hook from react-router-dom.
  *
  * This helps improve performance by reducing component re-renders when
- * navigation functions are passed as props or used in dependency arrays.
+ * navigation is used in a component or passed as a prop.
  */
 
 'use strict';

--- a/lib/rules/no-use-navigate-import-from-react-router-dom.js
+++ b/lib/rules/no-use-navigate-import-from-react-router-dom.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Disallow useNavigate import from react-router-dom
+ *
+ * useStableNavigate is a memoized version that prevents unnecessary re-renders
+ * that can occur with the standard useNavigate hook from react-router-dom.
+ *
+ * This helps improve performance by reducing component re-renders when
+ * navigation functions are passed as props or used in dependency arrays.
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'disallow useNavigate import from react-router-dom, use useStableNavigate instead to prevent re-renders',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      useStableNavigate:
+        'Use useStableNavigate instead of useNavigate to prevent unnecessary re-renders',
+    },
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'react-router-dom') {
+          const useNavigateSpecifier = node.specifiers.find(
+            (specifier) =>
+              specifier.type === 'ImportSpecifier' &&
+              specifier.imported.name === 'useNavigate',
+          );
+
+          if (useNavigateSpecifier) {
+            context.report({
+              node: useNavigateSpecifier,
+              messageId: 'useStableNavigate',
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidio/eslint-plugin-rules",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Additional eslint rules used in Tidio",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-use-navigate-import-from-react-router-dom.js
+++ b/tests/lib/rules/no-use-navigate-import-from-react-router-dom.js
@@ -1,0 +1,74 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/no-use-navigate-import-from-react-router-dom'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+RuleTester.setDefaultConfig({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+var ruleTester = new RuleTester();
+
+ruleTester.run('no-use-navigate-import-from-react-router-dom', rule, {
+  valid: [
+    {
+      code: `import { useStableNavigate } from '../../../utils/hooks'`,
+    },
+    {
+      code: `import { useLocation, useParams } from 'react-router-dom'`,
+    },
+    {
+      code: `import { Navigate } from 'react-router-dom'`,
+    },
+    {
+      code: `import { Routes, Route, BrowserRouter } from 'react-router-dom'`,
+    },
+    {
+      code: `import React from 'react'`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { useNavigate } from 'react-router-dom'`,
+      errors: [
+        {
+          messageId: 'useStableNavigate',
+          type: 'ImportSpecifier',
+        },
+      ],
+    },
+    {
+      code: `import { useNavigate, useLocation } from 'react-router-dom'`,
+      errors: [
+        {
+          messageId: 'useStableNavigate',
+          type: 'ImportSpecifier',
+        },
+      ],
+    },
+    {
+      code: `import { Routes, Route, useNavigate, Navigate } from 'react-router-dom'`,
+      errors: [
+        {
+          messageId: 'useStableNavigate',
+          type: 'ImportSpecifier',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Adds a new ESLint rule that disallows importing `useNavigate` from `react-router-dom` and enforces using `useStableNavigate` instead to prevent unnecessary re-renders. 

**Why?**
`useNavigate` creates new function references on every render, causing performance issues.